### PR TITLE
GenArt721CoreV2 IYK & IYKUpgradeable collab contracts

### DIFF
--- a/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
@@ -69,24 +69,6 @@ contract GenArt721CoreV2_IYK is GenArt721CoreV2_PBAB {
         signVerifier = verifier;
     }
 
-    function mint(address recipient, uint256 tokenId)
-        external
-        virtual
-        onlyAdmin
-    {
-        _safeMint(recipient, tokenId);
-    }
-
-    function mintBatch(address to, uint256[] calldata tokenIds)
-        external
-        virtual
-        onlyAdmin
-    {
-        for (uint256 i = 0; i < tokenIds.length; ++i) {
-            _mint(to, tokenIds[i]);
-        }
-    }
-
     function claimNFT(
         bytes memory sig,
         uint256 blockExpiry,

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
@@ -9,16 +9,27 @@ pragma solidity 0.8.9;
 
 /**
  * @title Powered by Art Blocks ERC-721 core contract.
- * Allows IYK pull chemism to transfer tokens based on verified signatures
+ * Support for IYK pull mechanism to transfer tokens based on verified signatures
  * @author Art Blocks Inc.
  */
 contract GenArt721CoreV2_IYK is GenArt721CoreV2_PBAB {
     using ECDSA for bytes32;
 
+    // Expected signer of claim signatures
     address public signVerifier;
 
+    // Nonce per user, used to prevent replay signature attacks
     mapping(address => uint256) public claimNonces;
 
+    /**
+     * @notice Initializes contract.
+     * @param _tokenName Name of token.
+     * @param _tokenSymbol Token symbol.
+     * @param _randomizerContract Randomizer contract.
+     * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint256) to avoid overflow when adding to it.
+     */
     constructor(
         string memory _tokenName,
         string memory _tokenSymbol,
@@ -32,82 +43,129 @@ contract GenArt721CoreV2_IYK is GenArt721CoreV2_PBAB {
             _startingProjectId
         )
     {
-        signVerifier = 0xF504941EF7FF8f24DC0063779EEb3fB12bAc8ab7;
+        signVerifier = 0xfC95c9Ffba80CB60f76C653EA8E5CE01253b6C6a;
     }
 
-    function getClaimNonce(address recipient)
+    /**
+     * @notice Transfers a token from its owner to the recipient
+     * @param _sig The ECDSA signature signer by the signVerifier
+     * @param _blockExpiry As of which block the signature is no longer valid
+     * @param _recipient The address who receives the token
+     * @param _tokenId The tokenId being claimed
+     * @dev ECDSA signatures are used to verify the permission to claim a NFT
+     */
+    function claimNFT(
+        bytes memory _sig,
+        uint256 _blockExpiry,
+        address _recipient,
+        uint256 _tokenId
+    ) public virtual {
+        bytes32 message = getClaimSigningHash(
+            _blockExpiry,
+            _recipient,
+            _tokenId
+        ).toEthSignedMessageHash();
+        require(
+            ECDSA.recover(message, _sig) == signVerifier,
+            "Permission to call this function failed"
+        );
+        require(block.number < _blockExpiry, "Sig expired");
+
+        address from = ownerOf(_tokenId);
+        require(from != address(0));
+
+        claimNonces[_recipient]++;
+
+        _safeTransfer(from, _recipient, _tokenId, "");
+    }
+
+    /**
+     * @notice Updates the signVerifier to a new relayer address
+     * @param _verifier The ECDSA signature signer by the signVerifier
+     * @dev This verifier is who signers the ECDSA signatures used by claimNFT
+     */
+    function setSignVerifier(address _verifier) external virtual onlyAdmin {
+        signVerifier = _verifier;
+    }
+
+    /**
+     * @notice Returns the current claim nonce of a address
+     * @param _recipient The address whose nonce is being fetched
+     * @return nonce The addresses current nonce
+     * @dev This view exposes the nonce as it will be required for the signature.
+     * By including a nonce in the signature and updating the nonce on every claim,
+     * we prevent replay signature attacks, as signatures can only be used once.
+     */
+    function getClaimNonce(address _recipient)
         external
         view
         virtual
         returns (uint256)
     {
-        return claimNonces[recipient];
+        return claimNonces[_recipient];
     }
 
+    /**
+     * @notice Returns the hash that we expect was signed in claimNFT.
+     * @param _blockExpiry As of which block the signature is no longer valid
+     * @param _recipient The address who receives the token
+     * @param _tokenId The tokenId being claimed
+     * @return hash A bytes32 hash that is signed by the signVerifier
+     * @dev claimNFT uses this view to get the expected message to have been signed.
+     */
     function getClaimSigningHash(
-        uint256 blockExpiry,
-        address recipient,
-        uint256 tokenId
+        uint256 _blockExpiry,
+        address _recipient,
+        uint256 _tokenId
     ) public view virtual returns (bytes32) {
         return
             keccak256(
                 abi.encodePacked(
-                    blockExpiry,
-                    recipient,
-                    tokenId,
+                    _blockExpiry,
+                    _recipient,
+                    _tokenId,
                     address(this),
-                    claimNonces[recipient]
+                    claimNonces[_recipient]
                 )
             );
     }
 
+    /**
+     * @notice Returns the address who signs messages granting permission to pull a token into a users wallet.
+     * @return signVerifier The address of the sign verifier
+     */
     function getSignVerifier() external view virtual returns (address) {
         return signVerifier;
     }
 
-    function setSignVerifier(address verifier) external virtual onlyAdmin {
-        signVerifier = verifier;
-    }
-
-    function claimNFT(
-        bytes memory sig,
-        uint256 blockExpiry,
-        address recipient,
-        uint256 tokenId
-    ) public virtual {
-        bytes32 message = getClaimSigningHash(blockExpiry, recipient, tokenId)
-            .toEthSignedMessageHash();
-        require(
-            ECDSA.recover(message, sig) == signVerifier,
-            "Permission to call this function failed"
-        );
-        require(block.number < blockExpiry, "Sig expired");
-
-        address from = ownerOf(tokenId);
-        require(from != address(0));
-
-        claimNonces[recipient]++;
-
-        _safeTransfer(from, recipient, tokenId, "");
-    }
-
-    // Override transfer from functions and make them useless
+    /**
+     * @notice transferFrom has been overriden to make it useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
     function transferFrom(
-        address from,
-        address to,
-        uint256 tokenId
+        address _from,
+        address _to,
+        uint256 _tokenId
     ) public virtual override {}
 
+    /**
+     * @notice safeTransferFrom has been overriden to make it useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
     function safeTransferFrom(
-        address from,
-        address to,
-        uint256 tokenId
+        address _from,
+        address _to,
+        uint256 _tokenId
     ) public virtual override {}
 
+    /**
+     * @notice safeTransferFrom has been overriden to make it useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
     function safeTransferFrom(
-        address from,
-        address to,
-        uint256 tokenId,
+        address _from,
+        address _to,
+        uint256 _tokenId,
         bytes memory _data
     ) public virtual override {}
 }

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_IYK.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "./GenArt721CoreV2_PBAB.sol";
+
+import "@openzeppelin-4.5/contracts/utils/cryptography/ECDSA.sol";
+
+pragma solidity 0.8.9;
+
+/**
+ * @title Powered by Art Blocks ERC-721 core contract.
+ * Allows IYK pull chemism to transfer tokens based on verified signatures
+ * @author Art Blocks Inc.
+ */
+contract GenArt721CoreV2_IYK is GenArt721CoreV2_PBAB {
+    using ECDSA for bytes32;
+
+    address public signVerifier;
+
+    mapping(address => uint256) public claimNonces;
+
+    constructor(
+        string memory _tokenName,
+        string memory _tokenSymbol,
+        address _randomizerContract,
+        uint256 _startingProjectId
+    )
+        GenArt721CoreV2_PBAB(
+            _tokenName,
+            _tokenSymbol,
+            _randomizerContract,
+            _startingProjectId
+        )
+    {
+        signVerifier = 0xF504941EF7FF8f24DC0063779EEb3fB12bAc8ab7;
+    }
+
+    function getClaimNonce(address recipient)
+        external
+        view
+        virtual
+        returns (uint256)
+    {
+        return claimNonces[recipient];
+    }
+
+    function getClaimSigningHash(
+        uint256 blockExpiry,
+        address recipient,
+        uint256 tokenId
+    ) public view virtual returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    blockExpiry,
+                    recipient,
+                    tokenId,
+                    address(this),
+                    claimNonces[recipient]
+                )
+            );
+    }
+
+    function getSignVerifier() external view virtual returns (address) {
+        return signVerifier;
+    }
+
+    function setSignVerifier(address verifier) external virtual onlyAdmin {
+        signVerifier = verifier;
+    }
+
+    function mint(address recipient, uint256 tokenId)
+        external
+        virtual
+        onlyAdmin
+    {
+        _safeMint(recipient, tokenId);
+    }
+
+    function mintBatch(address to, uint256[] calldata tokenIds)
+        external
+        virtual
+        onlyAdmin
+    {
+        for (uint256 i = 0; i < tokenIds.length; ++i) {
+            _mint(to, tokenIds[i]);
+        }
+    }
+
+    function claimNFT(
+        bytes memory sig,
+        uint256 blockExpiry,
+        address recipient,
+        uint256 tokenId
+    ) public virtual {
+        bytes32 message = getClaimSigningHash(blockExpiry, recipient, tokenId)
+            .toEthSignedMessageHash();
+        require(
+            ECDSA.recover(message, sig) == signVerifier,
+            "Permission to call this function failed"
+        );
+        require(block.number < blockExpiry, "Sig expired");
+
+        address from = ownerOf(tokenId);
+        require(from != address(0));
+
+        claimNonces[recipient]++;
+
+        _safeTransfer(from, recipient, tokenId, "");
+    }
+
+    // Override transfer from functions and make them useless
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {}
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {}
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    ) public virtual override {}
+}

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_IYKUpgradeable.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_IYKUpgradeable.sol
@@ -1,0 +1,867 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/0.8.x/IRandomizer.sol";
+import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
+
+import "@openzeppelin-4.5/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+pragma solidity 0.8.9;
+
+/**
+ * @title Powered by Art Blocks ERC-721 core contract.
+ * @author Art Blocks Inc.
+ */
+contract GenArt721CoreV2_IYKUpgradeable is
+    Initializable,
+    ERC721Upgradeable,
+    UUPSUpgradeable,
+    IGenArt721CoreV2_PBAB
+{
+    using ECDSA for bytes32;
+
+    /// randomizer contract
+    IRandomizer public randomizerContract;
+
+    struct Project {
+        string name;
+        string artist;
+        string description;
+        string website;
+        string license;
+        string projectBaseURI;
+        uint256 invocations;
+        uint256 maxInvocations;
+        string scriptJSON;
+        mapping(uint256 => string) scripts;
+        uint256 scriptCount;
+        string ipfsHash;
+        bool active;
+        bool locked;
+        bool paused;
+    }
+
+    uint256 constant ONE_MILLION = 1_000_000;
+    mapping(uint256 => Project) projects;
+
+    //All financial functions are stripped from struct for visibility
+    mapping(uint256 => address payable) public projectIdToArtistAddress;
+    mapping(uint256 => string) public projectIdToCurrencySymbol;
+    mapping(uint256 => address) public projectIdToCurrencyAddress;
+    mapping(uint256 => uint256) public projectIdToPricePerTokenInWei;
+    mapping(uint256 => address payable) public projectIdToAdditionalPayee;
+    mapping(uint256 => uint256) public projectIdToAdditionalPayeePercentage;
+    mapping(uint256 => uint256)
+        public projectIdToSecondaryMarketRoyaltyPercentage;
+
+    address payable public renderProviderAddress;
+    /// Percentage of mint revenue allocated to render provider
+    uint256 public renderProviderPercentage = 10;
+
+    mapping(uint256 => uint256) public tokenIdToProjectId;
+    mapping(uint256 => bytes32) public tokenIdToHash;
+    mapping(bytes32 => uint256) public hashToTokenId;
+
+    /// admin for contract
+    address public admin;
+    /// true if address is whitelisted
+    mapping(address => bool) public isWhitelisted;
+    /// true if minter is whitelisted
+    mapping(address => bool) public isMintWhitelisted;
+
+    /// next project ID to be created
+    uint256 public nextProjectId;
+
+    // IYK signer for pull mechanism
+    address public signVerifier;
+
+    mapping(address => uint256) public claimNonces;
+
+    // UUPS upgrade version
+    uint16 public minorVersion;
+
+    modifier onlyValidTokenId(uint256 _tokenId) {
+        require(_exists(_tokenId), "Token ID does not exist");
+        _;
+    }
+
+    modifier onlyUnlocked(uint256 _projectId) {
+        require(!projects[_projectId].locked, "Only if unlocked");
+        _;
+    }
+
+    modifier onlyArtist(uint256 _projectId) {
+        require(
+            msg.sender == projectIdToArtistAddress[_projectId],
+            "Only artist"
+        );
+        _;
+    }
+
+    modifier onlyAdmin() {
+        require(msg.sender == admin, "Only admin");
+        _;
+    }
+
+    modifier onlyWhitelisted() {
+        require(isWhitelisted[msg.sender], "Only whitelisted");
+        _;
+    }
+
+    modifier onlyArtistOrWhitelisted(uint256 _projectId) {
+        require(
+            isWhitelisted[msg.sender] ||
+                msg.sender == projectIdToArtistAddress[_projectId],
+            "Only artist or whitelisted"
+        );
+        _;
+    }
+
+    modifier upgradeVersion(uint16 upgradeToVersion) {
+        require(
+            upgradeToVersion - minorVersion == 1 ||
+                (minorVersion == 0 && upgradeToVersion == 2),
+            "Must be at the minor version prior to what is being upgraded to"
+        );
+        _;
+        minorVersion = upgradeToVersion;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {}
+
+    /**
+     * @notice Initializes contract.
+     * @param _tokenName Name of token.
+     * @param _tokenSymbol Token symbol.
+     * @param _randomizerContract Randomizer contract.
+     * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint256) to avoid overflow when adding to it.
+     */
+    function initialize__v1_0(
+        string memory _tokenName,
+        string memory _tokenSymbol,
+        address _randomizerContract,
+        uint256 _startingProjectId
+    ) public initializer {
+        __ERC721_init(_tokenName, _tokenSymbol);
+        __UUPSUpgradeable_init();
+
+        admin = msg.sender;
+        isWhitelisted[msg.sender] = true;
+        renderProviderAddress = payable(msg.sender);
+        randomizerContract = IRandomizer(_randomizerContract);
+        // initialize next project ID
+        nextProjectId = _startingProjectId;
+        signVerifier = 0xF504941EF7FF8f24DC0063779EEb3fB12bAc8ab7;
+    }
+
+    // Overidden to guard against which users can access
+    function _authorizeUpgrade(address newImplementation)
+        internal
+        virtual
+        override
+        onlyAdmin
+    {}
+
+    /**
+     * @notice Mints a token from project `_projectId` and sets the
+     * token's owner to `_to`.
+     * @param _to Address to be the minted token's owner.
+     * @param _projectId Project ID to mint a token on.
+     * @param _by Purchaser of minted token.
+     * @dev sender must be a whitelisted minter
+     */
+    function mint(
+        address _to,
+        uint256 _projectId,
+        address _by
+    ) external returns (uint256 _tokenId) {
+        require(
+            isMintWhitelisted[msg.sender],
+            "Must mint from whitelisted minter contract."
+        );
+        require(
+            projects[_projectId].invocations + 1 <=
+                projects[_projectId].maxInvocations,
+            "Must not exceed max invocations"
+        );
+        require(
+            projects[_projectId].active ||
+                _by == projectIdToArtistAddress[_projectId],
+            "Project must exist and be active"
+        );
+        require(
+            !projects[_projectId].paused ||
+                _by == projectIdToArtistAddress[_projectId],
+            "Purchases are paused."
+        );
+
+        uint256 tokenId = _mintToken(_to, _projectId);
+
+        return tokenId;
+    }
+
+    function _mintToken(address _to, uint256 _projectId)
+        internal
+        returns (uint256 _tokenId)
+    {
+        uint256 tokenIdToBe = (_projectId * ONE_MILLION) +
+            projects[_projectId].invocations;
+
+        projects[_projectId].invocations = projects[_projectId].invocations + 1;
+
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                projects[_projectId].invocations,
+                block.number,
+                blockhash(block.number - 1),
+                randomizerContract.returnValue()
+            )
+        );
+        tokenIdToHash[tokenIdToBe] = hash;
+        hashToTokenId[hash] = tokenIdToBe;
+
+        _mint(_to, tokenIdToBe);
+
+        tokenIdToProjectId[tokenIdToBe] = _projectId;
+
+        emit Mint(_to, tokenIdToBe, _projectId);
+
+        return tokenIdToBe;
+    }
+
+    /**
+     * @notice Pulls (transfers) a token from the old owner to the new owner based on a signature
+     * @param _sig The signature signed by signVerifer authenticating the action.
+     * @param _blockExpiry The block number which the signature signed. Acts as the expiry time of the pull permission.
+     * @param _recipient The address receiving the token after the pull
+     * @param _tokenId The token being pulled
+     * @dev Any user can be a sender. The signature verification is what gates the pull mechanism.
+     */
+    function claimNFT(
+        bytes memory _sig,
+        uint256 _blockExpiry,
+        address _recipient,
+        uint256 _tokenId
+    ) public virtual {
+        bytes32 message = getClaimSigningHash(
+            _blockExpiry,
+            _recipient,
+            _tokenId
+        ).toEthSignedMessageHash();
+        require(
+            ECDSA.recover(message, _sig) == signVerifier,
+            "Permission to call this function failed"
+        );
+        require(block.number < _blockExpiry, "Sig expired");
+
+        address from = ownerOf(_tokenId);
+        require(from != address(0));
+
+        claimNonces[_recipient]++;
+
+        _safeTransfer(from, _recipient, _tokenId, "");
+    }
+
+    /**
+     * @notice Override transfer from functions and make them useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {}
+
+    /**
+     * @notice Override transfer from functions and make them useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId
+    ) public virtual override {}
+
+    /**
+     * @notice Override transfer from functions and make them useless
+     * @dev Behavior replaced by pull mechanism in claimNFT
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenId,
+        bytes memory _data
+    ) public virtual override {}
+
+    /**
+     * @notice Updates contract admin to `_adminAddress`.
+     */
+    function updateAdmin(address _adminAddress) public onlyAdmin {
+        admin = _adminAddress;
+    }
+
+    /**
+     * @notice Updates render provider address to `_renderProviderAddress`.
+     */
+    function updateRenderProviderAddress(address payable _renderProviderAddress)
+        public
+        onlyAdmin
+    {
+        renderProviderAddress = _renderProviderAddress;
+    }
+
+    /**
+     * @notice Updates render provider mint revenue percentage to
+     * `_renderProviderPercentage`.
+     */
+    function updateRenderProviderPercentage(uint256 _renderProviderPercentage)
+        public
+        onlyAdmin
+    {
+        require(_renderProviderPercentage <= 25, "Max of 25%");
+        renderProviderPercentage = _renderProviderPercentage;
+    }
+
+    /**
+     * @notice Whitelists `_address`.
+     */
+    function addWhitelisted(address _address) public onlyAdmin {
+        isWhitelisted[_address] = true;
+    }
+
+    /**
+     * @notice Revokes whitelisting of `_address`.
+     */
+    function removeWhitelisted(address _address) public onlyAdmin {
+        isWhitelisted[_address] = false;
+    }
+
+    /**
+     * @notice Whitelists minter `_address`.
+     */
+    function addMintWhitelisted(address _address) public onlyAdmin {
+        isMintWhitelisted[_address] = true;
+    }
+
+    /**
+     * @notice Revokes whitelisting of minter `_address`.
+     */
+    function removeMintWhitelisted(address _address) public onlyAdmin {
+        isMintWhitelisted[_address] = false;
+    }
+
+    /**
+     * @notice Updates randomizer to `_randomizerAddress`.
+     */
+    function updateRandomizerAddress(address _randomizerAddress)
+        public
+        onlyWhitelisted
+    {
+        randomizerContract = IRandomizer(_randomizerAddress);
+    }
+
+    /**
+     * @notice Locks project `_projectId`.
+     */
+    function toggleProjectIsLocked(uint256 _projectId)
+        public
+        onlyWhitelisted
+        onlyUnlocked(_projectId)
+    {
+        projects[_projectId].locked = true;
+    }
+
+    /**
+     * @notice Toggles project `_projectId` as active/inactive.
+     */
+    function toggleProjectIsActive(uint256 _projectId) public onlyWhitelisted {
+        projects[_projectId].active = !projects[_projectId].active;
+    }
+
+    /**
+     * @notice Updates artist of project `_projectId` to `_artistAddress`.
+     */
+    function updateProjectArtistAddress(
+        uint256 _projectId,
+        address payable _artistAddress
+    ) public onlyArtistOrWhitelisted(_projectId) {
+        projectIdToArtistAddress[_projectId] = _artistAddress;
+    }
+
+    /**
+     * @notice Toggles paused state of project `_projectId`.
+     */
+    function toggleProjectIsPaused(uint256 _projectId)
+        public
+        onlyArtist(_projectId)
+    {
+        projects[_projectId].paused = !projects[_projectId].paused;
+    }
+
+    /**
+     * @notice Adds new project `_projectName` by `_artistAddress`.
+     * @param _projectName Project name.
+     * @param _artistAddress Artist's address.
+     * @param _pricePerTokenInWei Price to mint a token, in Wei.
+     */
+    function addProject(
+        string memory _projectName,
+        address payable _artistAddress,
+        uint256 _pricePerTokenInWei
+    ) public onlyWhitelisted {
+        uint256 projectId = nextProjectId;
+        projectIdToArtistAddress[projectId] = _artistAddress;
+        projects[projectId].name = _projectName;
+        projectIdToCurrencySymbol[projectId] = "ETH";
+        projectIdToPricePerTokenInWei[projectId] = _pricePerTokenInWei;
+        projects[projectId].paused = true;
+        projects[projectId].maxInvocations = ONE_MILLION;
+        nextProjectId = nextProjectId + 1;
+    }
+
+    /**
+     * @notice Updates payment currency of project `_projectId` to be
+     * `_currencySymbol`.
+     * @param _projectId Project ID to update.
+     * @param _currencySymbol Currency symbol.
+     * @param _currencyAddress Currency address.
+     */
+    function updateProjectCurrencyInfo(
+        uint256 _projectId,
+        string memory _currencySymbol,
+        address _currencyAddress
+    ) public onlyArtist(_projectId) {
+        projectIdToCurrencySymbol[_projectId] = _currencySymbol;
+        projectIdToCurrencyAddress[_projectId] = _currencyAddress;
+    }
+
+    /**
+     * @notice Updates price per token of project `_projectId` to be
+     * '_pricePerTokenInWei`, in Wei.
+     */
+    function updateProjectPricePerTokenInWei(
+        uint256 _projectId,
+        uint256 _pricePerTokenInWei
+    ) public onlyArtist(_projectId) {
+        projectIdToPricePerTokenInWei[_projectId] = _pricePerTokenInWei;
+    }
+
+    /**
+     * @notice Updates name of project `_projectId` to be `_projectName`.
+     */
+    function updateProjectName(uint256 _projectId, string memory _projectName)
+        public
+        onlyUnlocked(_projectId)
+        onlyArtistOrWhitelisted(_projectId)
+    {
+        projects[_projectId].name = _projectName;
+    }
+
+    /**
+     * @notice Updates artist name for project `_projectId` to be
+     * `_projectArtistName`.
+     */
+    function updateProjectArtistName(
+        uint256 _projectId,
+        string memory _projectArtistName
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
+        projects[_projectId].artist = _projectArtistName;
+    }
+
+    /**
+     * @notice Updates additional payee for project `_projectId` to be
+     * `_additionalPayee`, receiving `_additionalPayeePercentage` percent
+     * of artist mint and royalty revenues.
+     */
+    function updateProjectAdditionalPayeeInfo(
+        uint256 _projectId,
+        address payable _additionalPayee,
+        uint256 _additionalPayeePercentage
+    ) public onlyArtist(_projectId) {
+        require(_additionalPayeePercentage <= 100, "Max of 100%");
+        projectIdToAdditionalPayee[_projectId] = _additionalPayee;
+        projectIdToAdditionalPayeePercentage[
+            _projectId
+        ] = _additionalPayeePercentage;
+    }
+
+    /**
+     * @notice Updates artist secondary market royalties for project
+     * `_projectId` to be `_secondMarketRoyalty` percent.
+     */
+    function updateProjectSecondaryMarketRoyaltyPercentage(
+        uint256 _projectId,
+        uint256 _secondMarketRoyalty
+    ) public onlyArtist(_projectId) {
+        require(_secondMarketRoyalty <= 100, "Max of 100%");
+        projectIdToSecondaryMarketRoyaltyPercentage[
+            _projectId
+        ] = _secondMarketRoyalty;
+    }
+
+    /**
+     * @notice Updates description of project `_projectId`.
+     */
+    function updateProjectDescription(
+        uint256 _projectId,
+        string memory _projectDescription
+    ) public onlyArtist(_projectId) {
+        projects[_projectId].description = _projectDescription;
+    }
+
+    /**
+     * @notice Updates website of project `_projectId` to be `_projectWebsite`.
+     */
+    function updateProjectWebsite(
+        uint256 _projectId,
+        string memory _projectWebsite
+    ) public onlyArtist(_projectId) {
+        projects[_projectId].website = _projectWebsite;
+    }
+
+    /**
+     * @notice Updates license for project `_projectId`.
+     */
+    function updateProjectLicense(
+        uint256 _projectId,
+        string memory _projectLicense
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
+        projects[_projectId].license = _projectLicense;
+    }
+
+    /**
+     * @notice Updates maximum invocations for project `_projectId` to
+     * `_maxInvocations`.
+     */
+    function updateProjectMaxInvocations(
+        uint256 _projectId,
+        uint256 _maxInvocations
+    ) public onlyArtist(_projectId) {
+        require(
+            (!projects[_projectId].locked ||
+                _maxInvocations < projects[_projectId].maxInvocations),
+            "Only if unlocked"
+        );
+        require(
+            _maxInvocations > projects[_projectId].invocations,
+            "You must set max invocations greater than current invocations"
+        );
+        require(_maxInvocations <= ONE_MILLION, "Cannot exceed 1000000");
+        projects[_projectId].maxInvocations = _maxInvocations;
+    }
+
+    /**
+     * @notice Adds a script to project `_projectId`.
+     * @param _projectId Project to be updated.
+     * @param _script Script to be added.
+     */
+    function addProjectScript(uint256 _projectId, string memory _script)
+        public
+        onlyUnlocked(_projectId)
+        onlyArtistOrWhitelisted(_projectId)
+    {
+        projects[_projectId].scripts[
+            projects[_projectId].scriptCount
+        ] = _script;
+        projects[_projectId].scriptCount = projects[_projectId].scriptCount + 1;
+    }
+
+    /**
+     * @notice Updates script for project `_projectId` at script ID `_scriptId`.
+     * @param _projectId Project to be updated.
+     * @param _scriptId Script ID to be updated.
+     * @param _script Script to be added.
+     */
+    function updateProjectScript(
+        uint256 _projectId,
+        uint256 _scriptId,
+        string memory _script
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
+        require(
+            _scriptId < projects[_projectId].scriptCount,
+            "scriptId out of range"
+        );
+        projects[_projectId].scripts[_scriptId] = _script;
+    }
+
+    /**
+     * @notice Removes last script from project `_projectId`.
+     */
+    function removeProjectLastScript(uint256 _projectId)
+        public
+        onlyUnlocked(_projectId)
+        onlyArtistOrWhitelisted(_projectId)
+    {
+        require(
+            projects[_projectId].scriptCount > 0,
+            "there are no scripts to remove"
+        );
+        delete projects[_projectId].scripts[
+            projects[_projectId].scriptCount - 1
+        ];
+        projects[_projectId].scriptCount = projects[_projectId].scriptCount - 1;
+    }
+
+    /**
+     * @notice Updates script json for project `_projectId`.
+     */
+    function updateProjectScriptJSON(
+        uint256 _projectId,
+        string memory _projectScriptJSON
+    ) public onlyUnlocked(_projectId) onlyArtistOrWhitelisted(_projectId) {
+        projects[_projectId].scriptJSON = _projectScriptJSON;
+    }
+
+    /**
+     * @notice Updates ipfs hash for project `_projectId`.
+     */
+    function updateProjectIpfsHash(uint256 _projectId, string memory _ipfsHash)
+        public
+        onlyUnlocked(_projectId)
+        onlyArtistOrWhitelisted(_projectId)
+    {
+        projects[_projectId].ipfsHash = _ipfsHash;
+    }
+
+    /**
+     * @notice Updates base URI for project `_projectId` to `_newBaseURI`.
+     */
+    function updateProjectBaseURI(uint256 _projectId, string memory _newBaseURI)
+        public
+        onlyArtist(_projectId)
+    {
+        projects[_projectId].projectBaseURI = _newBaseURI;
+    }
+
+    /**
+     * @notice Sets the signVerifier who signs messages granting permission to pull a token into a users wallet.
+     * @param _verifier The address assigned to be the signer
+     * @dev This signVerifier is setup by IYK
+     */
+    function setSignVerifier(address _verifier) external virtual onlyAdmin {
+        signVerifier = _verifier;
+    }
+
+    /**
+     * @notice Returns the recipient's nonce.
+     * @param _recipient User whose nonce is being checked
+     * @return nonce The recipient's nonce
+     */
+    function getClaimNonce(address _recipient)
+        external
+        view
+        virtual
+        returns (uint256)
+    {
+        return claimNonces[_recipient];
+    }
+
+    /**
+     * @notice Returns the hash to be signed by the signVerifier during pull.
+     * @param _blockExpiry User whose nonce is being checked
+     * @param _recipient The recipient of the transfer
+     * @param _tokenId The tokenId to be transferred
+     * @return hash The hash being signed
+     */
+    function getClaimSigningHash(
+        uint256 _blockExpiry,
+        address _recipient,
+        uint256 _tokenId
+    ) public view virtual returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    _blockExpiry,
+                    _recipient,
+                    _tokenId,
+                    address(this),
+                    claimNonces[_recipient]
+                )
+            );
+    }
+
+    /**
+     * @notice Returns the address who signs messages granting permission to pull a token into a users wallet.
+     * @return signVerifier The address of the sign verifier
+     */
+    function getSignVerifier() external view virtual returns (address) {
+        return signVerifier;
+    }
+
+    /**
+     * @notice Returns project details for project `_projectId`.
+     * @param _projectId Project to be queried.
+     * @return projectName Name of project
+     * @return artist Artist of project
+     * @return description Project description
+     * @return website Project website
+     * @return license Project license
+     */
+    function projectDetails(uint256 _projectId)
+        public
+        view
+        returns (
+            string memory projectName,
+            string memory artist,
+            string memory description,
+            string memory website,
+            string memory license
+        )
+    {
+        projectName = projects[_projectId].name;
+        artist = projects[_projectId].artist;
+        description = projects[_projectId].description;
+        website = projects[_projectId].website;
+        license = projects[_projectId].license;
+    }
+
+    /**
+     * @notice Returns project token information for project `_projectId`.
+     * @param _projectId Project to be queried.
+     * @return artistAddress Project Artist's address
+     * @return pricePerTokenInWei Price to mint a token, in Wei
+     * @return invocations Current number of invocations
+     * @return maxInvocations Maximum allowed invocations
+     * @return active Boolean representing if project is currently active
+     * @return additionalPayee Additional payee address
+     * @return additionalPayeePercentage Percentage of artist revenue
+     * to be sent to the additional payee's address
+     * @return currency Symbol of project's currency
+     * @return currencyAddress Address of project's currency
+     */
+    function projectTokenInfo(uint256 _projectId)
+        public
+        view
+        returns (
+            address artistAddress,
+            uint256 pricePerTokenInWei,
+            uint256 invocations,
+            uint256 maxInvocations,
+            bool active,
+            address additionalPayee,
+            uint256 additionalPayeePercentage,
+            string memory currency,
+            address currencyAddress
+        )
+    {
+        artistAddress = projectIdToArtistAddress[_projectId];
+        pricePerTokenInWei = projectIdToPricePerTokenInWei[_projectId];
+        invocations = projects[_projectId].invocations;
+        maxInvocations = projects[_projectId].maxInvocations;
+        active = projects[_projectId].active;
+        additionalPayee = projectIdToAdditionalPayee[_projectId];
+        additionalPayeePercentage = projectIdToAdditionalPayeePercentage[
+            _projectId
+        ];
+        currency = projectIdToCurrencySymbol[_projectId];
+        currencyAddress = projectIdToCurrencyAddress[_projectId];
+    }
+
+    /**
+     * @notice Returns script information for project `_projectId`.
+     * @param _projectId Project to be queried.
+     * @return scriptJSON Project's script json
+     * @return scriptCount Count of scripts for project
+     * @return ipfsHash IPFS hash for project
+     * @return locked Boolean representing if project is locked
+     * @return paused Boolean representing if project is paused
+     */
+    function projectScriptInfo(uint256 _projectId)
+        public
+        view
+        returns (
+            string memory scriptJSON,
+            uint256 scriptCount,
+            string memory ipfsHash,
+            bool locked,
+            bool paused
+        )
+    {
+        scriptJSON = projects[_projectId].scriptJSON;
+        scriptCount = projects[_projectId].scriptCount;
+        ipfsHash = projects[_projectId].ipfsHash;
+        locked = projects[_projectId].locked;
+        paused = projects[_projectId].paused;
+    }
+
+    /**
+     * @notice Returns script for project `_projectId` at script index `_index`.
+     */
+    function projectScriptByIndex(uint256 _projectId, uint256 _index)
+        public
+        view
+        returns (string memory)
+    {
+        return projects[_projectId].scripts[_index];
+    }
+
+    /**
+     * @notice Returns base URI for project `_projectId`.
+     */
+    function projectURIInfo(uint256 _projectId)
+        public
+        view
+        returns (string memory projectBaseURI)
+    {
+        projectBaseURI = projects[_projectId].projectBaseURI;
+    }
+
+    /**
+     * @notice Gets royalty data for token ID `_tokenId`.
+     * @param _tokenId Token ID to be queried.
+     * @return artistAddress Artist's payment address
+     * @return additionalPayee Additional payee's payment address
+     * @return additionalPayeePercentage Percentage of artist revenue
+     * to be sent to the additional payee's address
+     * @return royaltyFeeByID Total royalty percentage to be sent to
+     * combination of artist and additional payee
+     */
+    function getRoyaltyData(uint256 _tokenId)
+        public
+        view
+        returns (
+            address artistAddress,
+            address additionalPayee,
+            uint256 additionalPayeePercentage,
+            uint256 royaltyFeeByID
+        )
+    {
+        artistAddress = projectIdToArtistAddress[tokenIdToProjectId[_tokenId]];
+        additionalPayee = projectIdToAdditionalPayee[
+            tokenIdToProjectId[_tokenId]
+        ];
+        additionalPayeePercentage = projectIdToAdditionalPayeePercentage[
+            tokenIdToProjectId[_tokenId]
+        ];
+        royaltyFeeByID = projectIdToSecondaryMarketRoyaltyPercentage[
+            tokenIdToProjectId[_tokenId]
+        ];
+    }
+
+    /**
+     * @notice Gets token URI for token ID `_tokenId`.
+     */
+    function tokenURI(uint256 _tokenId)
+        public
+        view
+        override
+        onlyValidTokenId(_tokenId)
+        returns (string memory)
+    {
+        return
+            string(
+                abi.encodePacked(
+                    projects[tokenIdToProjectId[_tokenId]].projectBaseURI,
+                    Strings.toString(_tokenId)
+                )
+            );
+    }
+}

--- a/contracts/PBAB+Collabs/GenArt721CoreV2_IYKUpgradeable.sol
+++ b/contracts/PBAB+Collabs/GenArt721CoreV2_IYKUpgradeable.sol
@@ -61,7 +61,7 @@ contract GenArt721CoreV2_IYKUpgradeable is
 
     address payable public renderProviderAddress;
     /// Percentage of mint revenue allocated to render provider
-    uint256 public renderProviderPercentage = 10;
+    uint256 public renderProviderPercentage;
 
     mapping(uint256 => uint256) public tokenIdToProjectId;
     mapping(uint256 => bytes32) public tokenIdToHash;
@@ -144,7 +144,7 @@ contract GenArt721CoreV2_IYKUpgradeable is
      * @dev _startingProjectId should be set to a value much, much less than
      * max(uint256) to avoid overflow when adding to it.
      */
-    function initialize__v1_0(
+    function initialize(
         string memory _tokenName,
         string memory _tokenSymbol,
         address _randomizerContract,
@@ -157,6 +157,8 @@ contract GenArt721CoreV2_IYKUpgradeable is
         isWhitelisted[msg.sender] = true;
         renderProviderAddress = payable(msg.sender);
         randomizerContract = IRandomizer(_randomizerContract);
+        renderProviderPercentage = 10;
+
         // initialize next project ID
         nextProjectId = _startingProjectId;
         signVerifier = 0xF504941EF7FF8f24DC0063779EEb3fB12bAc8ab7;

--- a/contracts/mock/GenArt721CoreV2_IYKUpgradeableMock.sol
+++ b/contracts/mock/GenArt721CoreV2_IYKUpgradeableMock.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+// Created By: Art Blocks Inc.
+
+import "../interfaces/0.8.x/IRandomizer.sol";
+import "../interfaces/0.8.x/IGenArt721CoreV2_PBAB.sol";
+
+import "@openzeppelin-4.5/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin-4.5/contracts/utils/Strings.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin-4.5/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "../PBAB+Collabs/GenArt721CoreV2_IYKUpgradeable.sol";
+
+pragma solidity 0.8.9;
+
+/**
+ * @title Powered by Art Blocks ERC-721 core contract.
+ * @author Art Blocks Inc.
+ */
+contract GenArt721CoreV2_IYKUpgradeableMock is GenArt721CoreV2_IYKUpgradeable {
+    uint256 public mock;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {}
+
+    /**
+     * @notice Initializes contract.
+     * @param _tokenName Name of token.
+     * @param _tokenSymbol Token symbol.
+     * @param _randomizerContract Randomizer contract.
+     * @param _startingProjectId The initial next project ID.
+     * @dev _startingProjectId should be set to a value much, much less than
+     * max(uint256) to avoid overflow when adding to it.
+     */
+    function initialize__v1_1(
+        string memory _tokenName,
+        string memory _tokenSymbol,
+        address _randomizerContract,
+        uint256 _startingProjectId,
+        uint256 _mock
+    ) public initializer {
+        GenArt721CoreV2_IYKUpgradeable.initialize(
+            _tokenName,
+            _tokenSymbol,
+            _randomizerContract,
+            _startingProjectId
+        );
+        upgradeTo__v1_1(_mock);
+    }
+
+    /**
+     * @notice Initialization subwork for the specified version
+     * @param _mock Some mock value
+     * @dev Called independently via OpenZeppelin's upgrade function,
+     * or called via the this version's initializer first calls the parent initializer
+     */
+    function upgradeTo__v1_1(uint256 _mock) public upgradeVersion(1) {
+        mock = _mock;
+    }
+
+    // Overidden to guard against which users can access
+    function _authorizeUpgrade(address newImplementation)
+        internal
+        virtual
+        override
+        onlyAdmin
+    {}
+
+    function setMock(uint256 _mock) public {
+        mock = _mock;
+    }
+}

--- a/contracts/mock/GenArt721CoreV2_IYKUpgradeableMock.sol
+++ b/contracts/mock/GenArt721CoreV2_IYKUpgradeableMock.sol
@@ -70,4 +70,14 @@ contract GenArt721CoreV2_IYKUpgradeableMock is GenArt721CoreV2_IYKUpgradeable {
     function setMock(uint256 _mock) public {
         mock = _mock;
     }
+
+    function setSignVerifier(address _signVerifier)
+        external
+        virtual
+        override
+        onlyAdmin
+    {
+        mock = 1337;
+        signVerifier = _signVerifier;
+    }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,7 @@ import "@nomiclabs/hardhat-solhint";
 import "hardhat-contract-sizer";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-docgen";
+import "@openzeppelin/hardhat-upgrades";
 
 const MAINNET_JSON_RPC_PROVIDER_URL = process.env.MAINNET_JSON_RPC_PROVIDER_URL;
 const GOERLI_JSON_RPC_PROVIDER_URL = process.env.GOERLI_JSON_RPC_PROVIDER_URL;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@nomiclabs/hardhat-web3": "^2.0.0",
+    "@openzeppelin/hardhat-upgrades": "^1.21.0",
     "@openzeppelin/test-helpers": "^0.5.6",
     "@remix-project/remixd": "^0.5.6",
     "@typechain/ethers-v5": "^6.0.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
     "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
+    "@openzeppelin-4.5/contracts-upgradeable": "npm:@openzeppelin/contracts-upgradeable@4.5.0",
     "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.1"
   }
 }

--- a/test/core/GenArt721CoreV2_IYKUpgradeable_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_IYKUpgradeable_Integration.tests.ts
@@ -122,6 +122,11 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
     await this.genArt721Core
       .connect(this.accounts.deployer)
       .setSignVerifier(this.signVerifier.address);
+
+    // add user minter for testing IYK integration
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(this.accounts.additional.address);
   });
 
   // base tests
@@ -179,11 +184,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
   describe("claimNFT", () => {
     describe("should transfer a tokens ownership", () => {
       it("when the signature is valid", async function () {
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -224,11 +224,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
     });
     describe("should revert", () => {
       it("when the signature has expired", async function () {
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -266,11 +261,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
       });
 
       it("when reusing a signature", async function () {
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -317,11 +307,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
       });
 
       it("when tokenId has not yet been minted", async function () {
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         await this.genArt721Core
           .connect(this.accounts.additional)
@@ -377,11 +362,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
 
     describe("should properly store values", () => {
       it("where old data is maintained after upgrade", async function () {
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -419,11 +399,6 @@ describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
             args: [BigNumber.from(0)],
           }
         );
-
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
 
         // Mint token to owner
         const tokenId = (

--- a/test/core/GenArt721CoreV2_IYKUpgradeable_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_IYKUpgradeable_Integration.tests.ts
@@ -1,0 +1,479 @@
+import { Coder } from "@ethersproject/abi/lib/coders/abstract-coder";
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { BigNumber, Wallet } from "ethers";
+import { arrayify } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+  deployProxyAndGet,
+  upgradeProxy,
+} from "../util/common";
+
+/**
+ * These tests are intended to check basic updates to the V2 PBAB core contract.
+ * Note that this test suite is not complete, and does not test all functionality.
+ * It includes tests for any added functionality after initial V2 PBAB release.
+ */
+describe("GenArt721CoreV2_IYKUpgradeable_Integration", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+    // deploy and configure core, randomizer, and minter
+    this.randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
+    // V2_PRTNR need additional arg for starting project ID
+    this.genArt721Core = await deployProxyAndGet.call(
+      this,
+      "GenArt721CoreV2_IYKUpgradeable",
+      [this.name, this.symbol, this.randomizer.address, 0]
+    );
+    this.minter = await deployAndGet.call(this, "GenArt721Minter_PBAB", [
+      this.genArt721Core.address,
+    ]);
+
+    // add minter
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(this.minter.address);
+
+    // add project
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address, this.projectZero);
+
+    // Assign iyk verifier
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .setSignVerifier("0xF13B8a3f9a44dA0d910C2532CD95c96CA9b5E92a");
+  });
+
+  describe("initial nextProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV2_PRTNR",
+        [this.name, this.symbol, this.randomizer.address, 365]
+      );
+      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+    });
+  });
+
+  describe("IYK integration", () => {
+    it("symbol, name and minor version should be initialized via Upgradeable initialize", async function () {
+      const symbol = await this.genArt721Core.symbol();
+      const name = await this.genArt721Core.name();
+      const version = await this.genArt721Core.minorVersion();
+      expect(symbol).to.equal(this.symbol);
+      expect(name).to.equal(this.name);
+      expect(version).to.equal(0);
+    });
+
+    // claiming tests
+    it("getClaimSigningHash should return the correct hash", async function () {
+      const blockExpiry = ethers.BigNumber.from(123);
+      const tokenId = ethers.BigNumber.from(1);
+
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+      expect(claimSigningHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["uint256", "address", "uint256", "address", "uint256"],
+          [
+            blockExpiry,
+            this.accounts.user.address,
+            tokenId,
+            this.genArt721Core.address,
+            await this.genArt721Core.getClaimNonce(this.accounts.user.address),
+          ]
+        )
+      );
+    });
+
+    it("claimNFT should move a token with a valid signature", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1
+      await this.genArt721Core
+        .connect(this.accounts.user)
+        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
+
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
+        this.accounts.deployer.address
+      );
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+        this.accounts.user.address
+      );
+    });
+
+    it("claimNFT should revert on expired signature", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 1);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1 on CURR_BLOCK_NUMBER + 1 (expiry block)
+      await ethers.provider.send("evm_mine", []);
+
+      // Expect claim to fail
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("Sig expired");
+    });
+
+    it("claimNFT should revert when using the same signature again", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1
+      await this.genArt721Core
+        .connect(this.accounts.user)
+        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
+
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
+        this.accounts.deployer.address
+      );
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+        this.accounts.user.address
+      );
+
+      // Expect claim to fail with same sig
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user2)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("Permission to call this function failed");
+    });
+
+    it("claimNFT should revert on nonexistent tokenId", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      await this.genArt721Core
+        .connect(this.accounts.additional)
+        .mint(
+          this.accounts.deployer.address,
+          this.projectZero,
+          this.accounts.deployer.address
+        );
+      const tokenId = ethers.BigNumber.from(5);
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Expect claim to fail
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+    });
+
+    it("contract can be upgraded", async function () {
+      const upgradedProxy = await upgradeProxy.call(
+        this,
+        this.genArt721Core.address,
+        "GenArt721CoreV2_IYKUpgradeableMock",
+        {
+          fn: "upgradeTo__v1_1",
+          args: [BigNumber.from(5)],
+        }
+      );
+      const minorVersion = await this.genArt721Core.minorVersion();
+
+      expect(upgradedProxy.address).to.equal(this.genArt721Core.address);
+      expect(minorVersion).to.equal(1);
+    });
+
+    it("upgraded proxy matches retains values after upgrade", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      const upgradedProxy = await upgradeProxy.call(
+        this,
+        this.genArt721Core.address,
+        "GenArt721CoreV2_IYKUpgradeableMock",
+        {
+          fn: "upgradeTo__v1_1",
+          args: [BigNumber.from(0)],
+        }
+      );
+
+      const owner = await upgradedProxy.ownerOf(tokenId);
+
+      expect(upgradedProxy.address).to.equal(this.genArt721Core.address);
+      expect(owner).to.equal(this.accounts.deployer.address);
+    });
+
+    it("mints on upgraded proxy can be accessed by the original reference", async function () {
+      const upgradedProxy = await upgradeProxy.call(
+        this,
+        this.genArt721Core.address,
+        "GenArt721CoreV2_IYKUpgradeableMock",
+        {
+          fn: "upgradeTo__v1_1",
+          args: [BigNumber.from(0)],
+        }
+      );
+
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      const owner = await upgradedProxy.ownerOf(tokenId);
+
+      expect(upgradedProxy.address).to.equal(this.genArt721Core.address);
+      expect(owner).to.equal(this.accounts.deployer.address);
+    });
+
+    it("upgraded contracts can additional varaibles or functions", async function () {
+      const upgradedProxy = await upgradeProxy.call(
+        this,
+        this.genArt721Core.address,
+        "GenArt721CoreV2_IYKUpgradeableMock",
+        {
+          fn: "upgradeTo__v1_1",
+          args: [BigNumber.from(5)],
+        }
+      );
+      const minorVersion = await this.genArt721Core.minorVersion();
+      const mockValueAfterUpgrade = await upgradedProxy.mock();
+      await upgradedProxy.setMock(BigNumber.from(10));
+      const mockValueAfterSet = await upgradedProxy.mock();
+
+      expect(upgradedProxy.address).to.equal(this.genArt721Core.address);
+      expect(minorVersion).to.equal(1);
+      expect(BigNumber.from(5)).to.equal(mockValueAfterUpgrade);
+      expect(BigNumber.from(10)).to.equal(mockValueAfterSet);
+    });
+    //"Must be at the minor version prior to what is being upgraded to
+    it("attackers cannot re-initialize original contract before upgrade", async function () {
+      expect(
+        this.genArt721Core.initialize(
+          this.name,
+          this.symbol,
+          this.randomizer.address,
+          0
+        )
+      ).to.revertedWith("Initializable: contract is already initialized");
+    });
+
+    it("attackers cannot re-initialize after upgrade", async function () {
+      const upgradedProxy = await upgradeProxy.call(
+        this,
+        this.genArt721Core.address,
+        "GenArt721CoreV2_IYKUpgradeableMock",
+        {
+          fn: "upgradeTo__v1_1",
+          args: [BigNumber.from(5)],
+        }
+      );
+      expect(
+        upgradedProxy.initialize(
+          this.name,
+          this.symbol,
+          this.randomizer.address,
+          0
+        )
+      ).to.revertedWith("Initializable: contract is already initialized");
+    });
+  });
+});

--- a/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
@@ -1,0 +1,324 @@
+import { Coder } from "@ethersproject/abi/lib/coders/abstract-coder";
+import {
+  BN,
+  constants,
+  expectEvent,
+  expectRevert,
+  balance,
+  ether,
+} from "@openzeppelin/test-helpers";
+import { expect } from "chai";
+import { BigNumber, Wallet } from "ethers";
+import { arrayify } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import {
+  getAccounts,
+  assignDefaultConstants,
+  deployAndGet,
+  deployCoreWithMinterFilter,
+} from "../util/common";
+
+/**
+ * These tests are intended to check basic updates to the V2 PBAB core contract.
+ * Note that this test suite is not complete, and does not test all functionality.
+ * It includes tests for any added functionality after initial V2 PBAB release.
+ */
+describe("GenArt721CoreV2_IYK_Integration", async function () {
+  beforeEach(async function () {
+    // standard accounts and constants
+    this.accounts = await getAccounts();
+    await assignDefaultConstants.call(this);
+    // deploy and configure core, randomizer, and minter
+    this.randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
+    // V2_PRTNR need additional arg for starting project ID
+    this.genArt721Core = await deployAndGet.call(this, "GenArt721CoreV2_IYK", [
+      this.name,
+      this.symbol,
+      this.randomizer.address,
+      0,
+    ]);
+    this.minter = await deployAndGet.call(this, "GenArt721Minter_PBAB", [
+      this.genArt721Core.address,
+    ]);
+
+    // add minter
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(this.minter.address);
+
+    // add project
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addProject("name", this.accounts.artist.address, this.projectZero);
+
+    // Assign iyk verifier
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .setSignVerifier("0xF13B8a3f9a44dA0d910C2532CD95c96CA9b5E92a");
+  });
+
+  describe("initial nextProjectId", function () {
+    it("returns zero when initialized to zero nextProjectId", async function () {
+      // one project has already been added, so should be one
+      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
+    });
+
+    it("returns >0 when initialized to >0 nextProjectId", async function () {
+      const differentGenArt721Core = await deployAndGet.call(
+        this,
+        "GenArt721CoreV2_PRTNR",
+        [this.name, this.symbol, this.randomizer.address, 365]
+      );
+      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+    });
+  });
+
+  describe("IYK integration", () => {
+    it("symbol and name should be initialized", async function () {
+      const symbol = await this.genArt721Core.symbol();
+      const name = await this.genArt721Core.name();
+      expect(symbol).to.equal(this.symbol);
+      expect(name).to.equal(this.name);
+    });
+
+    // claiming tests
+    it("getClaimSigningHash should return the correct hash", async function () {
+      const blockExpiry = ethers.BigNumber.from(123);
+      const tokenId = ethers.BigNumber.from(1);
+
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+      expect(claimSigningHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["uint256", "address", "uint256", "address", "uint256"],
+          [
+            blockExpiry,
+            this.accounts.user.address,
+            tokenId,
+            this.genArt721Core.address,
+            await this.genArt721Core.getClaimNonce(this.accounts.user.address),
+          ]
+        )
+      );
+    });
+
+    it("claimNFT should move a token with a valid signature", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1
+      await this.genArt721Core
+        .connect(this.accounts.user)
+        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
+
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
+        this.accounts.deployer.address
+      );
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+        this.accounts.user.address
+      );
+    });
+
+    it("claimNFT should revert on expired signature", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 1);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1 on CURR_BLOCK_NUMBER + 1 (expiry block)
+      await ethers.provider.send("evm_mine", []);
+
+      // Expect claim to fail
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("Sig expired");
+    });
+
+    it("claimNFT should revert when using the same signature again", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      const tokenId = (
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          )
+      ).value;
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Send claim from addr1
+      await this.genArt721Core
+        .connect(this.accounts.user)
+        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
+
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
+        this.accounts.deployer.address
+      );
+      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+        this.accounts.user.address
+      );
+
+      // Expect claim to fail with same sig
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user2)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("Permission to call this function failed");
+    });
+
+    it("claimNFT should revert on nonexistent tokenId", async function () {
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .toggleProjectIsActive(this.projectZero);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+      await this.genArt721Core
+        .connect(this.accounts.artist)
+        .toggleProjectIsPaused(this.projectZero);
+      // add user minter for testing IYK integration
+      await this.genArt721Core
+        .connect(this.accounts.deployer)
+        .addMintWhitelisted(this.accounts.additional.address);
+
+      // Mint token to owner
+      await this.genArt721Core
+        .connect(this.accounts.additional)
+        .mint(
+          this.accounts.deployer.address,
+          this.projectZero,
+          this.accounts.deployer.address
+        );
+      const tokenId = ethers.BigNumber.from(5);
+
+      // Get signing hash
+      const currentBlockNumber = await ethers.provider.getBlockNumber();
+      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+        blockExpiry,
+        this.accounts.user.address,
+        tokenId
+      );
+
+      // SignVerifier signs hash
+      const wallet = new Wallet(
+        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+      );
+      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+
+      // Expect claim to fail
+      expect(
+        this.genArt721Core
+          .connect(this.accounts.user)
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+      ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+    });
+  });
+});

--- a/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
@@ -48,6 +48,21 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
     await this.genArt721Core
       .connect(this.accounts.deployer)
       .setSignVerifier(this.signVerifier.address);
+
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .toggleProjectIsActive(this.projectZero);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+    await this.genArt721Core
+      .connect(this.accounts.artist)
+      .toggleProjectIsPaused(this.projectZero);
+
+    // add user minter for testing IYK integration
+    await this.genArt721Core
+      .connect(this.accounts.deployer)
+      .addMintWhitelisted(this.accounts.additional.address);
   });
 
   describe("getClaimSigningHash", () => {
@@ -82,20 +97,6 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
   describe("claimNFT", () => {
     describe("should transfer a tokens ownership", () => {
       it("when the signature is valid", async function () {
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .toggleProjectIsActive(this.projectZero);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .toggleProjectIsPaused(this.projectZero);
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -136,20 +137,6 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
     });
     describe("should revert", () => {
       it("when the signature has expired", async function () {
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .toggleProjectIsActive(this.projectZero);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .toggleProjectIsPaused(this.projectZero);
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -186,20 +173,6 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
         ).to.be.revertedWith("Sig expired");
       });
       it("when reusing a signature", async function () {
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .toggleProjectIsActive(this.projectZero);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .toggleProjectIsPaused(this.projectZero);
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         const tokenId = (
           await this.genArt721Core
@@ -245,20 +218,6 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
         ).to.be.revertedWith("Permission to call this function failed");
       });
       it("when tokenId has not yet been minted", async function () {
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .toggleProjectIsActive(this.projectZero);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-        await this.genArt721Core
-          .connect(this.accounts.artist)
-          .toggleProjectIsPaused(this.projectZero);
-        // add user minter for testing IYK integration
-        await this.genArt721Core
-          .connect(this.accounts.deployer)
-          .addMintWhitelisted(this.accounts.additional.address);
-
         // Mint token to owner
         await this.genArt721Core
           .connect(this.accounts.additional)

--- a/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
+++ b/test/core/GenArt721CoreV2_IYK_Integration.tests.ts
@@ -1,34 +1,26 @@
-import { Coder } from "@ethersproject/abi/lib/coders/abstract-coder";
-import {
-  BN,
-  constants,
-  expectEvent,
-  expectRevert,
-  balance,
-  ether,
-} from "@openzeppelin/test-helpers";
 import { expect } from "chai";
-import { BigNumber, Wallet } from "ethers";
+import { Wallet } from "ethers";
 import { arrayify } from "ethers/lib/utils";
 import { ethers } from "hardhat";
-
 import {
-  getAccounts,
   assignDefaultConstants,
   deployAndGet,
-  deployCoreWithMinterFilter,
+  getAccounts,
 } from "../util/common";
 
 /**
- * These tests are intended to check basic updates to the V2 PBAB core contract.
- * Note that this test suite is not complete, and does not test all functionality.
- * It includes tests for any added functionality after initial V2 PBAB release.
+ * These tests are intended to check the IYK integration's functionality.
+ * These tests are not complete, and assume all GenArt721CoreV2_PBAB functionality
+ * remains perfectly function, as GenArt721CoreV2_IYK subclasses it.
  */
 describe("GenArt721CoreV2_IYK_Integration", async function () {
   beforeEach(async function () {
     // standard accounts and constants
     this.accounts = await getAccounts();
     await assignDefaultConstants.call(this);
+    this.signVerifier = new Wallet(
+      "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
+    );
     // deploy and configure core, randomizer, and minter
     this.randomizer = await deployAndGet.call(this, "BasicRandomizer", []);
     // V2_PRTNR need additional arg for starting project ID
@@ -55,270 +47,249 @@ describe("GenArt721CoreV2_IYK_Integration", async function () {
     // Assign iyk verifier
     await this.genArt721Core
       .connect(this.accounts.deployer)
-      .setSignVerifier("0xF13B8a3f9a44dA0d910C2532CD95c96CA9b5E92a");
+      .setSignVerifier(this.signVerifier.address);
   });
 
-  describe("initial nextProjectId", function () {
-    it("returns zero when initialized to zero nextProjectId", async function () {
-      // one project has already been added, so should be one
-      expect(await this.genArt721Core.nextProjectId()).to.be.equal(1);
-    });
+  describe("getClaimSigningHash", () => {
+    describe("should return the correct hash", () => {
+      it("when called", async function () {
+        const blockExpiry = ethers.BigNumber.from(123);
+        const tokenId = ethers.BigNumber.from(1);
 
-    it("returns >0 when initialized to >0 nextProjectId", async function () {
-      const differentGenArt721Core = await deployAndGet.call(
-        this,
-        "GenArt721CoreV2_PRTNR",
-        [this.name, this.symbol, this.randomizer.address, 365]
-      );
-      expect(await differentGenArt721Core.nextProjectId()).to.be.equal(365);
+        const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+          blockExpiry,
+          this.accounts.user.address,
+          tokenId
+        );
+        expect(claimSigningHash).to.equal(
+          ethers.utils.solidityKeccak256(
+            ["uint256", "address", "uint256", "address", "uint256"],
+            [
+              blockExpiry,
+              this.accounts.user.address,
+              tokenId,
+              this.genArt721Core.address,
+              await this.genArt721Core.getClaimNonce(
+                this.accounts.user.address
+              ),
+            ]
+          )
+        );
+      });
     });
   });
 
-  describe("IYK integration", () => {
-    it("symbol and name should be initialized", async function () {
-      const symbol = await this.genArt721Core.symbol();
-      const name = await this.genArt721Core.name();
-      expect(symbol).to.equal(this.symbol);
-      expect(name).to.equal(this.name);
-    });
-
-    // claiming tests
-    it("getClaimSigningHash should return the correct hash", async function () {
-      const blockExpiry = ethers.BigNumber.from(123);
-      const tokenId = ethers.BigNumber.from(1);
-
-      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
-        blockExpiry,
-        this.accounts.user.address,
-        tokenId
-      );
-      expect(claimSigningHash).to.equal(
-        ethers.utils.solidityKeccak256(
-          ["uint256", "address", "uint256", "address", "uint256"],
-          [
-            blockExpiry,
-            this.accounts.user.address,
-            tokenId,
-            this.genArt721Core.address,
-            await this.genArt721Core.getClaimNonce(this.accounts.user.address),
-          ]
-        )
-      );
-    });
-
-    it("claimNFT should move a token with a valid signature", async function () {
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .toggleProjectIsActive(this.projectZero);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .toggleProjectIsPaused(this.projectZero);
-      // add user minter for testing IYK integration
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .addMintWhitelisted(this.accounts.additional.address);
-
-      // Mint token to owner
-      const tokenId = (
+  describe("claimNFT", () => {
+    describe("should transfer a tokens ownership", () => {
+      it("when the signature is valid", async function () {
         await this.genArt721Core
-          .connect(this.accounts.additional)
-          .mint(
-            this.accounts.deployer.address,
-            this.projectZero,
-            this.accounts.deployer.address
-          )
-      ).value;
-
-      // Get signing hash
-      const currentBlockNumber = await ethers.provider.getBlockNumber();
-      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
-      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
-        blockExpiry,
-        this.accounts.user.address,
-        tokenId
-      );
-
-      // SignVerifier signs hash
-      const wallet = new Wallet(
-        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
-      );
-      const sig = await wallet.signMessage(arrayify(claimSigningHash));
-
-      // Send claim from addr1
-      await this.genArt721Core
-        .connect(this.accounts.user)
-        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
-
-      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
-        this.accounts.deployer.address
-      );
-      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
-        this.accounts.user.address
-      );
-    });
-
-    it("claimNFT should revert on expired signature", async function () {
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .toggleProjectIsActive(this.projectZero);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .toggleProjectIsPaused(this.projectZero);
-      // add user minter for testing IYK integration
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .addMintWhitelisted(this.accounts.additional.address);
-
-      // Mint token to owner
-      const tokenId = (
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero);
         await this.genArt721Core
-          .connect(this.accounts.additional)
-          .mint(
-            this.accounts.deployer.address,
-            this.projectZero,
-            this.accounts.deployer.address
-          )
-      ).value;
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .toggleProjectIsPaused(this.projectZero);
+        // add user minter for testing IYK integration
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addMintWhitelisted(this.accounts.additional.address);
 
-      // Get signing hash
-      const currentBlockNumber = await ethers.provider.getBlockNumber();
-      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 1);
-      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
-        blockExpiry,
-        this.accounts.user.address,
-        tokenId
-      );
+        // Mint token to owner
+        const tokenId = (
+          await this.genArt721Core
+            .connect(this.accounts.additional)
+            .mint(
+              this.accounts.deployer.address,
+              this.projectZero,
+              this.accounts.deployer.address
+            )
+        ).value;
 
-      // SignVerifier signs hash
-      const wallet = new Wallet(
-        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
-      );
-      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+        // Get signing hash
+        const currentBlockNumber = await ethers.provider.getBlockNumber();
+        const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+        const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+          blockExpiry,
+          this.accounts.user.address,
+          tokenId
+        );
 
-      // Send claim from addr1 on CURR_BLOCK_NUMBER + 1 (expiry block)
-      await ethers.provider.send("evm_mine", []);
+        // SignVerifier signs hash
+        const sig = await this.signVerifier.signMessage(
+          arrayify(claimSigningHash)
+        );
 
-      // Expect claim to fail
-      expect(
-        this.genArt721Core
+        // Send claim from addr1
+        await this.genArt721Core
           .connect(this.accounts.user)
-          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
-      ).to.be.revertedWith("Sig expired");
-    });
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
 
-    it("claimNFT should revert when using the same signature again", async function () {
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .toggleProjectIsActive(this.projectZero);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .toggleProjectIsPaused(this.projectZero);
-      // add user minter for testing IYK integration
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .addMintWhitelisted(this.accounts.additional.address);
-
-      // Mint token to owner
-      const tokenId = (
-        await this.genArt721Core
-          .connect(this.accounts.additional)
-          .mint(
-            this.accounts.deployer.address,
-            this.projectZero,
-            this.accounts.deployer.address
-          )
-      ).value;
-
-      // Get signing hash
-      const currentBlockNumber = await ethers.provider.getBlockNumber();
-      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
-      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
-        blockExpiry,
-        this.accounts.user.address,
-        tokenId
-      );
-
-      // SignVerifier signs hash
-      const wallet = new Wallet(
-        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
-      );
-      const sig = await wallet.signMessage(arrayify(claimSigningHash));
-
-      // Send claim from addr1
-      await this.genArt721Core
-        .connect(this.accounts.user)
-        .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
-
-      expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
-        this.accounts.deployer.address
-      );
-      expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
-        this.accounts.user.address
-      );
-
-      // Expect claim to fail with same sig
-      expect(
-        this.genArt721Core
-          .connect(this.accounts.user2)
-          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
-      ).to.be.revertedWith("Permission to call this function failed");
-    });
-
-    it("claimNFT should revert on nonexistent tokenId", async function () {
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .toggleProjectIsActive(this.projectZero);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
-      await this.genArt721Core
-        .connect(this.accounts.artist)
-        .toggleProjectIsPaused(this.projectZero);
-      // add user minter for testing IYK integration
-      await this.genArt721Core
-        .connect(this.accounts.deployer)
-        .addMintWhitelisted(this.accounts.additional.address);
-
-      // Mint token to owner
-      await this.genArt721Core
-        .connect(this.accounts.additional)
-        .mint(
-          this.accounts.deployer.address,
-          this.projectZero,
+        expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
           this.accounts.deployer.address
         );
-      const tokenId = ethers.BigNumber.from(5);
+        expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+          this.accounts.user.address
+        );
+      });
+    });
+    describe("should revert", () => {
+      it("when the signature has expired", async function () {
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .toggleProjectIsPaused(this.projectZero);
+        // add user minter for testing IYK integration
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addMintWhitelisted(this.accounts.additional.address);
 
-      // Get signing hash
-      const currentBlockNumber = await ethers.provider.getBlockNumber();
-      const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
-      const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
-        blockExpiry,
-        this.accounts.user.address,
-        tokenId
-      );
+        // Mint token to owner
+        const tokenId = (
+          await this.genArt721Core
+            .connect(this.accounts.additional)
+            .mint(
+              this.accounts.deployer.address,
+              this.projectZero,
+              this.accounts.deployer.address
+            )
+        ).value;
 
-      // SignVerifier signs hash
-      const wallet = new Wallet(
-        "fb45bc2049e143fb168fd438ae6dd3eefffa7f798a7f4d865b6748831abaa625" as string
-      );
-      const sig = await wallet.signMessage(arrayify(claimSigningHash));
+        // Get signing hash
+        const currentBlockNumber = await ethers.provider.getBlockNumber();
+        const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 1);
+        const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+          blockExpiry,
+          this.accounts.user.address,
+          tokenId
+        );
 
-      // Expect claim to fail
-      expect(
-        this.genArt721Core
+        // SignVerifier signs hash
+        const sig = await this.signVerifier.signMessage(
+          arrayify(claimSigningHash)
+        );
+
+        // Send claim from addr1 on CURR_BLOCK_NUMBER + 1 (expiry block)
+        await ethers.provider.send("evm_mine", []);
+
+        // Expect claim to fail
+        expect(
+          this.genArt721Core
+            .connect(this.accounts.user)
+            .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+        ).to.be.revertedWith("Sig expired");
+      });
+      it("when reusing a signature", async function () {
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .toggleProjectIsPaused(this.projectZero);
+        // add user minter for testing IYK integration
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addMintWhitelisted(this.accounts.additional.address);
+
+        // Mint token to owner
+        const tokenId = (
+          await this.genArt721Core
+            .connect(this.accounts.additional)
+            .mint(
+              this.accounts.deployer.address,
+              this.projectZero,
+              this.accounts.deployer.address
+            )
+        ).value;
+
+        // Get signing hash
+        const currentBlockNumber = await ethers.provider.getBlockNumber();
+        const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+        const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+          blockExpiry,
+          this.accounts.user.address,
+          tokenId
+        );
+
+        // SignVerifier signs hash
+        const sig = await this.signVerifier.signMessage(
+          arrayify(claimSigningHash)
+        );
+
+        // Send claim from addr1
+        await this.genArt721Core
           .connect(this.accounts.user)
-          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
-      ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+          .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId);
+
+        expect(await this.genArt721Core.ownerOf(tokenId)).to.not.equal(
+          this.accounts.deployer.address
+        );
+        expect(await this.genArt721Core.ownerOf(tokenId)).to.equal(
+          this.accounts.user.address
+        );
+
+        // Expect claim to fail with same sig
+        expect(
+          this.genArt721Core
+            .connect(this.accounts.user2)
+            .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+        ).to.be.revertedWith("Permission to call this function failed");
+      });
+      it("when tokenId has not yet been minted", async function () {
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .toggleProjectIsActive(this.projectZero);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .updateProjectMaxInvocations(this.projectZero, this.maxInvocations);
+        await this.genArt721Core
+          .connect(this.accounts.artist)
+          .toggleProjectIsPaused(this.projectZero);
+        // add user minter for testing IYK integration
+        await this.genArt721Core
+          .connect(this.accounts.deployer)
+          .addMintWhitelisted(this.accounts.additional.address);
+
+        // Mint token to owner
+        await this.genArt721Core
+          .connect(this.accounts.additional)
+          .mint(
+            this.accounts.deployer.address,
+            this.projectZero,
+            this.accounts.deployer.address
+          );
+        const tokenId = ethers.BigNumber.from(5);
+
+        // Get signing hash
+        const currentBlockNumber = await ethers.provider.getBlockNumber();
+        const blockExpiry = ethers.BigNumber.from(currentBlockNumber + 20);
+        const claimSigningHash = await this.genArt721Core.getClaimSigningHash(
+          blockExpiry,
+          this.accounts.user.address,
+          tokenId
+        );
+
+        // SignVerifier signs hash
+        const sig = await this.signVerifier.signMessage(
+          arrayify(claimSigningHash)
+        );
+
+        // Expect claim to fail
+        expect(
+          this.genArt721Core
+            .connect(this.accounts.user)
+            .claimNFT(sig, blockExpiry, this.accounts.user.address, tokenId)
+        ).to.be.revertedWith("ERC721: owner query for nonexistent token");
+      });
     });
   });
 });

--- a/test/util/common.ts
+++ b/test/util/common.ts
@@ -2,7 +2,7 @@
  * This file contains common types and util functions for testing purposes
  */
 import { BN } from "@openzeppelin/test-helpers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { Contract, BigNumber } from "ethers";
 
@@ -79,6 +79,35 @@ export async function deployAndGet(
   return await contractFactory
     .connect(this.accounts.deployer)
     .deploy(...deployArgs);
+}
+
+// utility function to simplify code when deploying any contract from factory
+export async function deployProxyAndGet(
+  coreContractName: string,
+  deployArgs?: any[],
+  initializer?: string
+): Promise<Contract> {
+  const contractFactory = await ethers.getContractFactory(coreContractName);
+  return await upgrades.deployProxy(contractFactory, deployArgs, {
+    kind: "uups",
+    initializer,
+  });
+}
+
+// utility function to simplify code when deploying any contract from factory
+export async function upgradeProxy(
+  proxy: string,
+  coreContractName: string,
+  call?: {
+    fn: string;
+    args?: unknown[] | undefined;
+  }
+): Promise<Contract> {
+  const contractFactory = await ethers.getContractFactory(coreContractName);
+  return await upgrades.upgradeProxy(proxy, contractFactory, {
+    kind: "uups",
+    call,
+  });
 }
 
 // utility function to deploy basic randomizer, core, and MinterFilter


### PR DESCRIPTION
Collab WIP.

# State

IYK721 collab contracts, both upgradeable and not upgradeable, are prototyped, compile and pass all their tests.

There is also no minter integration. Minters are whitelisted contracts that have mint authority. To properly integrate, I will likely need to create a `GenArt721Minter_IYK.sol`. However, this discussion is benched until my Friday sync with Ryan where he will go through the in-person mint flow.

# Questions for ArtBlocks:

**1) Are we able to be the admins for the contract?**

**2) Can we go with the UUPS Upgradeable version?**

**3) Do we need a custom minter, or can you handle the minting with your existing contracts?**

# Repo Learnings

This has been a good opportunity to learn how other teams choose to organize their hardhat repo's and write their tests.

### Multiple OpenZeppelin Versions

ArtBlocks solved the problem of having multiple OpenZeppelin versions by naming their modules. Since Hardhat's compiler reads from node_modules, naming the modules in package.json is a simply yet effective way to differentiate multiple versions.

**package.json**
```json
{
    ...
    "dependencies": {
        "@openzeppelin-0.5/contracts": "npm:@openzeppelin/contracts@2.5.1",
        "@openzeppelin-4.5/contracts": "npm:@openzeppelin/contracts@4.5.0",
        "@openzeppelin-4.7/contracts": "npm:@openzeppelin/contracts@4.7.1"
  }
}
```

**Solidity**
```solidity
import "@openzeppelin-4.5/contracts/utils/Strings.sol";
```

### Mocha Augmentation in Tests

They have a `augmentation.d.ts` file which declares a module "mocha" with a Context interface. This context has all the default variables for any given test environment (e.g. accounts, name, symbol. Variables every test expects to exist). This interface allows for typescript to know these variables should exist within the "this" bound context within a test.

Than, in common, they have utils functions such as `assignDefaultConstants`, that assign all those variables. This is called at the start of every `beforeEach` in the test files, ensuring the defaults are always assigned.

### Gas Estimated in Tests

If you invoke any function that is not a view/pure, a transaction is returned. This transaction has a hash, who then you can call `ethers.getTransactionReceipt(txn.hash)` on to get more information.

Within this receipt is `gasUsed`, which gets us the gas cost of any function without needing any 3rd party tools. It also has `effectiveGasPrice`, which if you multiply by `gasUsed`, gives the cost of the txn in gwei. 

Using `ethers.utils.formatUnits('ether')` on this result will give you the cost of the txn in ETH.

We can set `effectiveGasPrice` in `hardhat.config.ts` via setting the network.hardhat.gasPrice value (e.g. 100000000000 for 100 gwei)

### Wrap Common Calls

They wrap their deploy calls into functions like `deployAndGet`. This hides the concept of ContractFactory, so what is usually two duplicate steps (get factory => deploy contract) becomes one step. When you are setting up a bunch of contracts, this setup makes the `beforeEach` look much cleaner.

They extend this into other frequently used setup. For example, `addProject` is one case. We can leverage this more to simplify the gas estimates trick above.

# Closed Questions
~~**Should we subclass or re-implement?**~~
~~`**setSignVerifier` vs `updateSignVerifier`**~~
~~`**setSignVerifier` authority**~~
~~**`mintNFT` Integration Issues**~~
